### PR TITLE
feat: add datatype in context

### DIFF
--- a/whispering/schema.py
+++ b/whispering/schema.py
@@ -48,6 +48,8 @@ class Context(BaseModel, arbitrary_types_allowed=True):
     vad_threshold: float
     max_nospeech_skip: int
 
+    data_type: Optional[str] = "float32"
+
 
 class ParsedChunk(BaseModel):
     start: float

--- a/whispering/schema.py
+++ b/whispering/schema.py
@@ -48,7 +48,7 @@ class Context(BaseModel, arbitrary_types_allowed=True):
     vad_threshold: float
     max_nospeech_skip: int
 
-    data_type: Optional[str] = "float32"
+    data_type: str = "float32"
 
 
 class ParsedChunk(BaseModel):

--- a/whispering/schema.py
+++ b/whispering/schema.py
@@ -24,7 +24,7 @@ class WhisperConfig(BaseModel):
         return values
 
 
-CURRENT_PROTOCOL_VERSION: Final[int] = int("000_006_000")
+CURRENT_PROTOCOL_VERSION: Final[int] = int("000_006_002")
 
 
 class Context(BaseModel, arbitrary_types_allowed=True):

--- a/whispering/serve.py
+++ b/whispering/serve.py
@@ -9,7 +9,8 @@ import numpy as np
 import websockets
 from websockets.exceptions import ConnectionClosedOK
 
-from whispering.transcriber import Context, WhisperStreamingTranscriber
+from whispering.schema import Context
+from whispering.transcriber import WhisperStreamingTranscriber
 
 logger = getLogger(__name__)
 
@@ -66,7 +67,6 @@ async def serve_with_websocket_main(websocket):
             continue
 
         logger.debug(f"Message size: {len(message)}")
-        audio = np.frombuffer(message, dtype=np.dtype(ctx.data_type)).astype(np.float32)
         if ctx is None:
             await websocket.send(
                 json.dumps(
@@ -76,6 +76,7 @@ async def serve_with_websocket_main(websocket):
                 )
             )
             return
+        audio = np.frombuffer(message, dtype=np.dtype(ctx.data_type)).astype(np.float32)
         for chunk in g_wsp.transcribe(
             audio=audio,  # type: ignore
             ctx=ctx,

--- a/whispering/serve.py
+++ b/whispering/serve.py
@@ -66,7 +66,7 @@ async def serve_with_websocket_main(websocket):
             continue
 
         logger.debug(f"Message size: {len(message)}")
-        audio = np.frombuffer(message, dtype=np.float32)
+        audio = np.frombuffer(message, dtype=np.dtype(ctx.data_type)).astype(np.float32)
         if ctx is None:
             await websocket.send(
                 json.dumps(

--- a/whispering/serve.py
+++ b/whispering/serve.py
@@ -9,13 +9,13 @@ import numpy as np
 import websockets
 from websockets.exceptions import ConnectionClosedOK
 
-from whispering.schema import Context
+from whispering.schema import CURRENT_PROTOCOL_VERSION, Context
 from whispering.transcriber import WhisperStreamingTranscriber
 
 logger = getLogger(__name__)
 
 MIN_PROTOCOL_VERSION: Final[int] = int("000_006_000")
-MAX_PROTOCOL_VERSION: Final[int] = int("000_006_000")
+MAX_PROTOCOL_VERSION: Final[int] = CURRENT_PROTOCOL_VERSION
 
 
 async def serve_with_websocket_main(websocket):


### PR DESCRIPTION
This PR adds an option in the context to specify the datatype of the WebSocket binary data.

This will be used in https://github.com/jitsi/jigasi/pull/454 as it sends int64 data.

Please let me know if there is anything I can improve in this PR.